### PR TITLE
Fix couplet since server API changed.

### DIFF
--- a/plugins/couplet
+++ b/plugins/couplet
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 [ -z "$cmd_body" ] && msg_send "用法: /couplet <词语>" && exit 0
-msg_send "$(curl -s "https://ai-backend.binwang.me/chat/couplet/$(python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1])" "$cmd_body")" | jq -r ".output")"
+msg_send  "$(curl -s "https://ai-backend.binwang.me/v0.2/couplet/$(python3 -c "import sys, urllib.parse as ul; print(ul.quote_plus(sys.argv[1]))" "$cmd_body")" | jq -r ".output[0]")"


### PR DESCRIPTION
<https://ai.binwang.me/couplet> has moved to a new API endpoint and also changed its response schema. The new response looks like this:

```
$ curl -s "https://ai-backend.binwang.me/v0.2/couplet/我是测试" | jq .
{
  "output": [
    "鸡为将军",
    "鸡为跳弹",
    "鸡为将来",
    "妻为未来",
    "鸡为弹冠",
    "妻为演习",
    "鸡为将疑",
    "鸡为对弹",
    "鸡为升冠",
    "鸡为跳跳"
  ],
  "score": [
    -4.135515928268433,
    -4.734553575515747,
    -5.1745076179504395,
    -5.375935077667236,
    -5.502591371536255,
    -5.620962619781494,
    -5.684183597564697,
    -5.836905479431152,
    -5.926938056945801,
    -15.235624313354492
  ]
}
```

Therefore I changed the query URL to the new endpoint. Since it now returns multiple results, I choose to only respond the first result to the user.

Also, the python code was updated to Python3.